### PR TITLE
Returns Response::HTTP_UNAUTHORIZED instead of 403

### DIFF
--- a/Security/Authentication/Api/AppToken/HeaderAuthenticator.php
+++ b/Security/Authentication/Api/AppToken/HeaderAuthenticator.php
@@ -4,6 +4,7 @@ namespace RybakDigital\Bundle\AuthenticationBundle\Security\Authentication\Api\A
 
 use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -97,12 +98,9 @@ class HeaderAuthenticator extends AbstractGuardAuthenticator
     {
         $data = array(
             'message' => strtr($exception->getMessageKey(), $exception->getMessageData())
-
-            // or to translate this message
-            // $this->translator->trans($exception->getMessageKey(), $exception->getMessageData())
         );
 
-        return new JsonResponse($data, 403);
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
     }
 
     /**
@@ -115,7 +113,7 @@ class HeaderAuthenticator extends AbstractGuardAuthenticator
             'message' => 'Authentication Required'
         );
 
-        return new JsonResponse($data, 401);
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
     }
 
     public function supportsRememberMe()

--- a/Security/Authentication/Api/AppToken/ParameterAuthenticator.php
+++ b/Security/Authentication/Api/AppToken/ParameterAuthenticator.php
@@ -4,6 +4,7 @@ namespace RybakDigital\Bundle\AuthenticationBundle\Security\Authentication\Api\A
 
 use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -81,12 +82,9 @@ class ParameterAuthenticator extends AbstractGuardAuthenticator
     {
         $data = array(
             'message' => strtr($exception->getMessageKey(), $exception->getMessageData())
-
-            // or to translate this message
-            // $this->translator->trans($exception->getMessageKey(), $exception->getMessageData())
         );
 
-        return new JsonResponse($data, 403);
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
     }
 
     /**
@@ -99,7 +97,7 @@ class ParameterAuthenticator extends AbstractGuardAuthenticator
             'message' => 'Authentication Required'
         );
 
-        return new JsonResponse($data, 401);
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
     }
 
     public function supportsRememberMe()

--- a/Security/Authentication/Api/AppUserToken/HeaderAuthenticator.php
+++ b/Security/Authentication/Api/AppUserToken/HeaderAuthenticator.php
@@ -4,6 +4,7 @@ namespace RybakDigital\Bundle\AuthenticationBundle\Security\Authentication\Api\A
 
 use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -93,12 +94,9 @@ class HeaderAuthenticator extends AbstractGuardAuthenticator
     {
         $data = array(
             'message' => strtr($exception->getMessageKey(), $exception->getMessageData())
-
-            // or to translate this message
-            // $this->translator->trans($exception->getMessageKey(), $exception->getMessageData())
         );
 
-        return new JsonResponse($data, 403);
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
     }
 
     /**
@@ -111,7 +109,7 @@ class HeaderAuthenticator extends AbstractGuardAuthenticator
             'message' => 'Authentication Required'
         );
 
-        return new JsonResponse($data, 401);
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
     }
 
     public function supportsRememberMe()

--- a/Security/Authentication/Api/AppUserToken/ParameterAuthenticator.php
+++ b/Security/Authentication/Api/AppUserToken/ParameterAuthenticator.php
@@ -4,6 +4,7 @@ namespace RybakDigital\Bundle\AuthenticationBundle\Security\Authentication\Api\A
 
 use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -98,7 +99,7 @@ class ParameterAuthenticator extends AbstractGuardAuthenticator
             // $this->translator->trans($exception->getMessageKey(), $exception->getMessageData())
         );
 
-        return new JsonResponse($data, 403);
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
     }
 
     /**
@@ -111,7 +112,7 @@ class ParameterAuthenticator extends AbstractGuardAuthenticator
             'message' => 'Authentication Required'
         );
 
-        return new JsonResponse($data, 401);
+        return new JsonResponse($data, Response::HTTP_UNAUTHORIZED);
     }
 
     public function supportsRememberMe()

--- a/Tests/Security/Authentication/Api/AppToken/HeaderAuthenticatorTest.php
+++ b/Tests/Security/Authentication/Api/AppToken/HeaderAuthenticatorTest.php
@@ -242,7 +242,7 @@ class HeaderAuthenticatorTest extends TestCase
         $result = $headerAuthenticator->onAuthenticationFailure($request, $exception);
 
         $this->assertInstanceOf(JsonResponse::class, $result);
-        $this->assertEquals(403, $result->getStatusCode());
+        $this->assertEquals(401, $result->getStatusCode());
     }
 
     public function testStart()


### PR DESCRIPTION
* Wrong status was used:

There's a problem with 401 Unauthorized, the HTTP status code for authentication errors. And that’s just it: it’s for authentication, not authorization. Receiving a 401 response is the server telling you, “you aren’t authenticated–either not authenticated at all or authenticated incorrectly–but please reauthenticate and try again.” To help you out, it will always include a WWW-Authenticate header that describes how to authenticate.

This is a response generally returned by your web server, not your web application.

It’s also something very temporary; the server is asking you to try again.

So, for authorization I use the 403 Forbidden response. It’s permanent, it’s tied to my application logic, and it’s a more concrete response than a 401.

Receiving a 403 response is the server telling you, “I’m sorry. I know who you are–I believe who you say you are–but you just don’t have permission to access this resource. Maybe if you ask the system administrator nicely, you’ll get permission. But please don’t bother me again until your predicament changes.”

In summary, a 401 Unauthorized response should be used for missing or bad authentication, and a 403 Forbidden response should be used afterwards, when the user is authenticated but isn’t authorized to perform the requested operation on the given resource.